### PR TITLE
Add Github Actions for Testing and Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: 'publish'
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-20.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: install frontend dependencies
+        run: yarn install # change this to npm or pnpm depending on which one you use
+        
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
+          releaseName: 'App v__VERSION__'
+          releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true
+          prerelease: false

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -1,0 +1,39 @@
+name: 'test-on-pr'
+on: [pull_request]
+
+jobs:
+  test-tauri:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-20.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: install frontend dependencies
+        run: yarn install # change this to npm or pnpm depending on which one you use
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All noteable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Unreleased
+
+# 0.1.0 (19 November 2023)
+
+Initial Release

--- a/README.md
+++ b/README.md
@@ -25,27 +25,30 @@ Some basic options allow you to customize the view:
 <img src="public/solars_options.gif" />
 </div>
 
-## Build
+## Build & Development
 
-Clone this repository to your local machine. Since `solars` is a Tauri app, in order to build it, please follow the steps to build `solars` on your platform [here][tauri-build]. You will need one of Tauri's CLI utilities installed, e.g., `tauri-cli`:
+Clone this repository to your local machine. Since `solars` is a Tauri app, you may read the guides for [Developing Tauri apps][tauri-develop] and for [Building Tauri apps][tauri-build] on the official website.
+
+You will need one of Tauri's CLI utilities installed, e.g., `tauri-cli`:
 
 ```
 cargo install tauri-cli
+```
+
+You can then build the application bundle for your local operating system:
+
+```
 cargo tauri build
 ```
 
-Currently, `solars` is not distributed on any app platforms.
-
-[tauri-build]: https://tauri.app/v1/guides/building/
-
-## Development
-
-Clone this repository to your local machine. Since `solars` is a Tauri app, you can use the `tauri-cli` to run the development environment:
+Or, launch the development server:
 
 ```
-cargo install tauri-cli
 cargo tauri dev
 ```
+
+[tauri-build]: https://tauri.app/v1/guides/building/
+[tauri-develop]: https://tauri.app/v1/guides/development/development-cycle
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <div align="center">
 <img src="public/solars.svg" width="128px"/>
 <h1>solars</h1>
-</div>
-
 <p align="center"><i>Visualize the planets of our solar system</i></p>
+
+![GitHub all releases](https://img.shields.io/github/downloads/hiltontj/solars/total)
+
+</div>
 
 ## Overview
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solars",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2422,7 +2422,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "solars"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "astro",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "solars"
-version = "0.0.0"
+version = "0.1.0"
 description = "Visualize the planets of our solar system."
 authors = ["Trevor Hilton"]
 license = "MIT"
-repository = ""
+repository = "https://github.com/hiltontj/solars"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This PR adds the github actions to test Tauri builds on PR, and to publish the binaries on release.